### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the chruby cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: resources/install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 0.1.4 - *2021-08-18*
 
 Standardise files with files in sous-chefs/repo-management

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -18,6 +18,7 @@ property :template_cookbook, String,
          description: ''
 
 provides :chruby_install
+unified_mode true
 
 action :install do
   chruby_pgp_key_path = ::File.join(Chef::Config[:file_cache_path], 'chruby.tar.gz.asc')


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.9 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/install.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)