### PR TITLE
Enable unified_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This file is used to list changes made in each version of the chruby cookbook.
 
 ## Unreleased
 
+- Enable unified_mode on the install resource for Chef 17+ compatability
+- Require Chef 15.3 for unified mode support
+
 ## 0.1.4 - *2021-08-18*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 0.1.2 - 2020-09-16
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures chruby'
 version           '0.1.4'
 source_url        'https://github.com/sous-chefs/sc-chruby'
 issues_url        'https://github.com/sous-chefs/sc-chruby/issues'
-chef_version      '>= 14.0'
+chef_version      '>= 15.3'
 
 supports 'debian'
 supports 'ubuntu'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,3 +1,7 @@
+unified_mode true
+
+provides :chruby_install
+
 property :download_url, String,
          default: 'https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz',
          description: 'Download URL'
@@ -16,8 +20,6 @@ property :user, String,
 property :template_cookbook, String,
          default: 'sc-chruby',
          description: ''
-
-provides :chruby_install
 
 action :install do
   chruby_pgp_key_path = ::File.join(Chef::Config[:file_cache_path], 'chruby.tar.gz.asc')


### PR DESCRIPTION
# Description

- Enable unified_mode on the install resource for Chef 17+ compatibility
- Require Chef 15.3 for unified mode support

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
